### PR TITLE
Allow return values in async generators

### DIFF
--- a/Include/cpython/pyerrors.h
+++ b/Include/cpython/pyerrors.h
@@ -66,6 +66,11 @@ typedef struct {
 
 typedef struct {
     PyException_HEAD
+    PyObject *value;
+} PyStopAsyncIterationObject;
+
+typedef struct {
+    PyException_HEAD
     PyObject *name;
 } PyNameErrorObject;
 

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -42,6 +42,8 @@ PyAPI_FUNC(PyObject *) PyGen_NewWithQualName(PyFrameObject *,
     PyObject *name, PyObject *qualname);
 PyAPI_FUNC(int) _PyGen_SetStopIterationValue(PyObject *);
 PyAPI_FUNC(int) _PyGen_FetchStopIterationValue(PyObject **);
+PyAPI_FUNC(int) _PyGen_SetStopAsyncIterationValue(PyObject *);
+PyAPI_FUNC(int) _PyGen_FetchStopAsyncIterationValue(PyObject **);
 PyObject *_PyGen_yf(PyGenObject *);
 PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -493,8 +493,64 @@ SimpleExtendsException(PyExc_Exception, TypeError,
 /*
  *    StopAsyncIteration extends Exception
  */
-SimpleExtendsException(PyExc_Exception, StopAsyncIteration,
-                       "Signal the end from iterator.__anext__().");
+
+static PyMemberDef StopAsyncIteration_members[] = {
+    {"value", T_OBJECT, offsetof(PyStopAsyncIterationObject, value), 0,
+        PyDoc_STR("async generator return value")},
+    {NULL}  /* Sentinel */
+};
+
+static int
+StopAsyncIteration_init(PyStopAsyncIterationObject *self, PyObject *args, PyObject *kwds)
+{
+    Py_ssize_t size = PyTuple_GET_SIZE(args);
+    PyObject *value;
+
+    if (BaseException_init((PyBaseExceptionObject *)self, args, kwds) == -1)
+        return -1;
+    Py_CLEAR(self->value);
+    if (size > 0)
+        value = PyTuple_GET_ITEM(args, 0);
+    else
+        value = Py_None;
+    Py_INCREF(value);
+    self->value = value;
+    return 0;
+}
+
+static int
+StopAsyncIteration_clear(PyStopAsyncIterationObject *self)
+{
+    Py_CLEAR(self->value);
+    return BaseException_clear((PyBaseExceptionObject *)self);
+}
+
+static void
+StopAsyncIteration_dealloc(PyStopAsyncIterationObject *self)
+{
+    _PyObject_GC_UNTRACK(self);
+    StopAsyncIteration_clear(self);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static int
+StopAsyncIteration_traverse(PyStopAsyncIterationObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->value);
+    return BaseException_traverse((PyBaseExceptionObject *)self, visit, arg);
+}
+
+ComplexExtendsException(
+    PyExc_Exception,            /* base */
+    StopAsyncIteration,         /* name */
+    StopAsyncIteration,         /* prefix for *_init, etc */
+    0,                          /* new */
+    0,                          /* methods */
+    StopAsyncIteration_members, /* members */
+    0,                          /* getset */
+    0,                          /* str */
+    "Signal the end from iterator.__anext__()."
+);
 
 
 /*

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2469,12 +2469,6 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
                             && _PyErr_ExceptionMatches(tstate, PyExc_StopAsyncIteration))
                         call_exc_trace(tstate->c_tracefunc, tstate->c_traceobj, tstate, f);
 
-                    if (PyErr_ExceptionMatches(PyExc_StopAsyncIteration)) {
-                        _PyErr_Clear(tstate);
-
-                        gen_status = PYGEN_RETURN;
-                        retval = Py_None;
-                    }
                     if (_PyGen_FetchStopAsyncIterationValue(&retval) == 0) {
                         gen_status = PYGEN_RETURN;
                     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2475,12 +2475,12 @@ _PyEval_EvalFrameDefault(PyThreadState *tstate, PyFrameObject *f, int throwflag)
                         gen_status = PYGEN_RETURN;
                         retval = Py_None;
                     }
-                    /* if (_PyGen_FetchStopIterationValue(&retval) == 0) {
+                    if (_PyGen_FetchStopAsyncIterationValue(&retval) == 0) {
                         gen_status = PYGEN_RETURN;
                     }
                     else {
                         gen_status = PYGEN_ERROR;
-                    } */
+                    }
                 }
                 else {
                     gen_status = PYGEN_NEXT;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3059,15 +3059,11 @@ compiler_return(struct compiler *c, stmt_ty s)
                         (s->v.Return.value->kind != Constant_kind));
     if (c->u->u_ste->ste_type != FunctionBlock)
         return compiler_error(c, "'return' outside function");
-    if (s->v.Return.value != NULL &&
-        c->u->u_ste->ste_coroutine && c->u->u_ste->ste_generator)
-    {
-            return compiler_error(
-                c, "'return' with value in async generator");
-    }
+
     if (preserve_tos) {
         VISIT(c, expr, s->v.Return.value);
     } else {
+
         /* Emit instruction with line number for return value */
         if (s->v.Return.value != NULL) {
             SET_LOC(c, s->v.Return.value);

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,6 @@
 This is a fork of CPython with support ``yield from`` in async functions and a new ``async yield from`` instruction
 
 TODO:
-   * Add support for return in async generators (requires the StopAsyncIteration exception to be changed)
    * Add ``AsyncGenerator.ag_yieldfrom``
 
 .. code-block:: python


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
Adds a return value in async generators, so basically you can do this:
```py
>>> async def foo():
...     yield
...     return 1
...
>>> async def bar():
...     print((async yield from foo()))
...
>>> gen = bar()
>>> await anext(gen)
>>> try:
...     await anext(gen)
... except StopAsyncIteration as e:
...     pass
1
```
